### PR TITLE
updatng node name in config to work with NOV instruction doc  command

### DIFF
--- a/docker-makefiles/generic-configs/base_configs.env
+++ b/docker-makefiles/generic-configs/base_configs.env
@@ -4,7 +4,7 @@ LICENSE_KEY="124c0e81ed0daece22880124defda9eb94bd69b192582c32555905f0cd638c70717
 # Information regarding which AnyLog node configurations to enable. By default, even if everything is disabled, AnyLog starts TCP and REST connection protocols
 NODE_TYPE=generic
 # Name of the AnyLog instance
-NODE_NAME=anylog-node
+NODE_NAME=anylog-generic
 # Owner of the AnyLog instance
 COMPANY_NAME=Nov
 


### PR DESCRIPTION
make attach ANYLOG_TYPE=generic wasn't working because it expected the container name to be anylog-generic, whereas the generated container name was anylog-node. I updated the node name in the config so that the container name is anylog-generic.